### PR TITLE
ci: upload built artifacts to the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,3 +26,11 @@ jobs:
 
       - name: Publish to PyPI
         run: uv publish
+
+      - name: Upload build artifacts to GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
The sigstore method may not have been working,
but this still should