### PR TITLE
ci: get rid of the undraft step

### DIFF
--- a/.github/workflows/precommit-autoupdate.yaml
+++ b/.github/workflows/precommit-autoupdate.yaml
@@ -47,7 +47,9 @@ jobs:
           title: "pre-commit autoupdate"
           # Use the body of our temp file for the body of the PR
           body-path: tmp_create_pr_body.md
-          # Force draft for a start.
+          # start in draft, so that I can manually un-draft it,
+          # in order to trigger CI runs
+          # See: https://github.com/peter-evans/create-pull-request/issues/48
           draft: true
           # Only interested in updates to pre-commit config
           add-paths: |
@@ -58,10 +60,3 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
-
-      - name: "Undraft the PR"
-        if: ${{ steps.create-pr.outputs.pull-request-number }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          gh pr ready ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
Doesn't work. GH is clearly smarter than I in this regard.

I'll have to manually un-draft the changes each time.