### PR TITLE
ci: rename release workflow; set env var for project name

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -3,12 +3,15 @@ on:
   release:
     types: [published]
 
+env:
+  PROJECT_NAME: "type-stripper"
+
 jobs:
   release:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/type-stripper
+      url: https://pypi.org/p/${{ env.PROJECT_NAME }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Matches the standard I'm setting in my personal template