### PR TITLE
chore: dupe the version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "type-stripper"
-dynamic = ["version"]
+version = "0.1.5"
 description = "A CLI tool that removes type annotations from Python source files."
 readme = "README.md"
 authors = [
@@ -43,9 +43,6 @@ type-stripper = "type_stripper:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.version]
-path = "src/type_stripper/__init__.py"
 
 [tool.pytest.ini_options]
 addopts = """


### PR DESCRIPTION
There's an issue in CI at the moment.
Not willing to track it down.

I'll come back in a month, I think,
see if it resolves.